### PR TITLE
Add Node.js web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # code_run_test
+
+This repository contains a simple Python script that can execute source files written in multiple programming languages. The script detects the language by the file extension and invokes the appropriate interpreter or compiler.
+
+## Supported languages
+
+- Python (`.py`)
+- JavaScript (`.js`)
+- Ruby (`.rb`)
+- PHP (`.php`)
+- Perl (`.pl`)
+- C (`.c`)
+- C++ (`.cpp`)
+- Java (`.java`)
+
+## Command line usage
+
+```
+python run_code.py <path to source file>
+```
+
+Example:
+
+```
+python run_code.py samples/hello.py
+```
+
+The repository includes a `samples` directory with small example programs for each supported language.
+
+## Web interface
+
+The `server.js` script offers a tiny web UI using Node's built-in `http` module. Start it with:
+
+```
+node server.js
+```
+
+Then open `http://localhost:8000` in your browser, choose a language, paste your code, and click **Run** to execute it.

--- a/run_code.py
+++ b/run_code.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import subprocess
+import tempfile
+
+LANG_RUNNERS = {
+    '.py': ['python3'],
+    '.js': ['node'],
+    '.rb': ['ruby'],
+    '.php': ['php'],
+    '.pl': ['perl'],
+}
+
+COMPILED_LANGUAGES = {
+    '.c': {
+        'compile': ['gcc', '{src}', '-o', '{out}'],
+        'run': ['{out}']
+    },
+    '.cpp': {
+        'compile': ['g++', '{src}', '-o', '{out}'],
+        'run': ['{out}']
+    },
+    '.java': {
+        'compile': ['javac', '-d', '{outdir}', '{src}'],
+        'run': ['java', '-cp', '{outdir}', '{classname}']
+    }
+}
+
+def run_command(cmd):
+    result = subprocess.run(cmd, text=True, capture_output=True)
+    print(result.stdout, end='')
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    return result.returncode
+
+def run_script(path):
+    ext = os.path.splitext(path)[1]
+    if ext in LANG_RUNNERS:
+        cmd = LANG_RUNNERS[ext] + [path]
+        return run_command(cmd)
+    elif ext in COMPILED_LANGUAGES:
+        config = COMPILED_LANGUAGES[ext]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, 'prog')
+            classname = os.path.splitext(os.path.basename(path))[0]
+            compile_cmd = [arg.format(src=path, out=out, outdir=tmpdir, classname=classname) for arg in config['compile']]
+            rc = run_command(compile_cmd)
+            if rc != 0:
+                return rc
+            run_cmd = [arg.format(src=path, out=out, outdir=tmpdir, classname=classname) for arg in config['run']]
+            return run_command(run_cmd)
+    else:
+        raise ValueError(f"Unsupported file extension: {ext}")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python run_code.py <source_file>")
+        sys.exit(1)
+    source = sys.argv[1]
+    if not os.path.exists(source):
+        print(f"File not found: {source}")
+        sys.exit(1)
+    try:
+        rc = run_script(source)
+        sys.exit(rc)
+    except ValueError as exc:
+        print(exc)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/Hello.java
+++ b/samples/Hello.java
@@ -1,0 +1,5 @@
+public class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello from Java");
+    }
+}

--- a/samples/hello.c
+++ b/samples/hello.c
@@ -1,0 +1,2 @@
+#include <stdio.h>
+int main(){printf("Hello from C\n");return 0;}

--- a/samples/hello.cpp
+++ b/samples/hello.cpp
@@ -1,0 +1,2 @@
+#include <iostream>
+int main(){std::cout << "Hello from C++" << std::endl; return 0;}

--- a/samples/hello.js
+++ b/samples/hello.js
@@ -1,0 +1,1 @@
+console.log('Hello from JavaScript');

--- a/samples/hello.py
+++ b/samples/hello.py
@@ -1,0 +1,1 @@
+print('Hello from Python')

--- a/samples/hello.rb
+++ b/samples/hello.rb
@@ -1,0 +1,1 @@
+puts 'Hello from Ruby'

--- a/server.js
+++ b/server.js
@@ -1,0 +1,67 @@
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const LANGUAGE_EXT = {
+  python: '.py',
+  javascript: '.js',
+  ruby: '.rb',
+  php: '.php',
+  perl: '.pl',
+  c: '.c',
+  cpp: '.cpp',
+  java: '.java'
+};
+
+function runCode(lang, code) {
+  const ext = LANGUAGE_EXT[lang];
+  if (!ext) {
+    return `Unsupported language: ${lang}`;
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-'));
+  const file = path.join(dir, 'prog' + ext);
+  fs.writeFileSync(file, code);
+  const result = spawnSync('python3', ['run_code.py', file], { encoding: 'utf8' });
+  return result.stdout + result.stderr;
+}
+
+function handleRequest(req, res) {
+  if (req.method === 'POST' && req.url === '/run') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const lang = params.get('language');
+      const code = params.get('code') || '';
+      const output = runCode(lang, code);
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(output);
+    });
+  } else {
+    const options = Object.keys(LANGUAGE_EXT)
+      .map(l => `<option value="${l}">${l}</option>`) 
+      .join('\n');
+    const page = `<!doctype html>
+<title>Code Runner</title>
+<form method="post" action="/run">
+<select name="language">
+${options}
+</select><br>
+<textarea name="code" rows="10" cols="40"></textarea><br>
+<input type="submit" value="Run">
+</form>`;
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(page);
+  }
+}
+
+if (require.main === module) {
+  const port = parseInt(process.env.PORT || '8000', 10);
+  http.createServer(handleRequest).listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+} else {
+  module.exports = { runCode, handleRequest };
+}

--- a/test_run_code.py
+++ b/test_run_code.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+
+
+def run_sample(sample):
+    result = subprocess.run([sys.executable, 'run_code.py', sample], text=True, capture_output=True)
+    return result.stdout.strip(), result.returncode
+
+
+def test_python_sample():
+    out, rc = run_sample('samples/hello.py')
+    assert rc == 0
+    assert out == 'Hello from Python'
+
+
+def run_node(lang, code):
+    script = f"const r=require('./server.js');process.stdout.write(r.runCode('{lang}',`{code}`));"
+    result = subprocess.run(['node', '-e', script], text=True, capture_output=True)
+    return result.stdout.strip(), result.returncode
+
+
+def test_web_python():
+    out, rc = run_node('python', "print('OK')")
+    assert rc == 0
+    assert 'OK' in out


### PR DESCRIPTION
## Summary
- switch web interface from Python WSGI to Node
- update docs for the new `server.js`
- add tests that invoke the Node handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847b5765a208324a304a7096eb9711b