### PR TITLE
Add dependency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # code_run_test
+
+This repository contains a simple Python script that can execute source files written in multiple programming languages. The script detects the language by the file extension and invokes the appropriate interpreter or compiler.
+
+## Supported languages
+
+- Python (`.py`)
+- JavaScript (`.js`)
+- Ruby (`.rb`)
+- PHP (`.php`)
+- Perl (`.pl`)
+- C (`.c`)
+- C++ (`.cpp`)
+- Java (`.java`)
+
+## Command line usage
+
+```
+python run_code.py <path to source file>
+```
+
+Example:
+
+```
+python run_code.py samples/hello.py
+```
+
+The repository includes a `samples` directory with small example programs for each supported language.
+
+### Installing dependencies
+
+Use the `--deps` option to specify packages to install before running the program:
+
+```
+python run_code.py samples/use_local.py --deps libs/localpkg
+```
+
+The runner installs Python packages with `pip` and JavaScript packages with `npm` into a temporary directory and adjusts environment variables so the executed program can import them.
+
+## Web interface
+
+The `server.js` script offers a tiny web UI using Node's built-in `http` module. Start it with:
+
+```
+node server.js
+```
+
+Then open `http://localhost:8000` in your browser, choose a language, paste your code, and click **Run** to execute it.
+You can also list dependencies in the **Dependencies** field (space separated) before running.

--- a/libs/localpkg/localpkg/__init__.py
+++ b/libs/localpkg/localpkg/__init__.py
@@ -1,0 +1,2 @@
+def value():
+    return 42

--- a/libs/localpkg/setup.py
+++ b/libs/localpkg/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup, find_packages
+setup(name='localpkg', version='0.1', packages=find_packages())

--- a/libs/stringer/index.js
+++ b/libs/stringer/index.js
@@ -1,0 +1,3 @@
+module.exports = function(str) {
+  return str.split('').reverse().join('');
+};

--- a/libs/stringer/package.json
+++ b/libs/stringer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "stringer",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/run_code.py
+++ b/run_code.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import subprocess
+import tempfile
+import argparse
+
+LANG_RUNNERS = {
+    '.py': ['python3'],
+    '.js': ['node'],
+    '.rb': ['ruby'],
+    '.php': ['php'],
+    '.pl': ['perl'],
+}
+
+COMPILED_LANGUAGES = {
+    '.c': {
+        'compile': ['gcc', '{src}', '-o', '{out}'],
+        'run': ['{out}']
+    },
+    '.cpp': {
+        'compile': ['g++', '{src}', '-o', '{out}'],
+        'run': ['{out}']
+    },
+    '.java': {
+        'compile': ['javac', '-d', '{outdir}', '{src}'],
+        'run': ['java', '-cp', '{outdir}', '{classname}']
+    }
+}
+
+def run_command(cmd, env=None, cwd=None):
+    result = subprocess.run(cmd, text=True, capture_output=True, env=env, cwd=cwd)
+    print(result.stdout, end='')
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    return result.returncode
+
+def install_dependencies(ext, deps, depdir):
+    env = {}
+    if not deps:
+        return env
+    if ext == '.py':
+        local_paths = []
+        install_deps = []
+        for d in deps:
+            if os.path.exists(d):
+                local_paths.append(os.path.abspath(d))
+            else:
+                install_deps.append(d)
+        if install_deps:
+            run_command(['pip', 'install', '--target', depdir] + install_deps)
+            local_paths.append(depdir)
+        env['PYTHONPATH'] = os.pathsep.join(local_paths)
+    elif ext == '.js':
+        run_command(['npm', 'init', '-y'], cwd=depdir)
+        dep_args = []
+        for d in deps:
+            if os.path.exists(d):
+                dep_args.append(os.path.abspath(d))
+            else:
+                dep_args.append(d)
+        run_command(['npm', 'install', '--prefix', depdir] + dep_args)
+        env['NODE_PATH'] = os.path.join(depdir, 'node_modules')
+    return env
+
+
+def run_script(path, deps=None):
+    deps = deps or []
+    ext = os.path.splitext(path)[1]
+    with tempfile.TemporaryDirectory() as depdir:
+        env = os.environ.copy()
+        env.update(install_dependencies(ext, deps, depdir))
+
+        if ext in LANG_RUNNERS:
+            cmd = LANG_RUNNERS[ext] + [path]
+            return run_command(cmd, env=env)
+        elif ext in COMPILED_LANGUAGES:
+            config = COMPILED_LANGUAGES[ext]
+            with tempfile.TemporaryDirectory() as tmpdir:
+                out = os.path.join(tmpdir, 'prog')
+                classname = os.path.splitext(os.path.basename(path))[0]
+                compile_cmd = [arg.format(src=path, out=out, outdir=tmpdir, classname=classname) for arg in config['compile']]
+                rc = run_command(compile_cmd, env=env)
+                if rc != 0:
+                    return rc
+                run_cmd = [arg.format(src=path, out=out, outdir=tmpdir, classname=classname) for arg in config['run']]
+                return run_command(run_cmd, env=env)
+        else:
+            raise ValueError(f"Unsupported file extension: {ext}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run code in various languages")
+    parser.add_argument('source', help='Source file to execute')
+    parser.add_argument('--deps', nargs='*', default=[], help='Dependencies to install')
+    args = parser.parse_args()
+
+    if not os.path.exists(args.source):
+        print(f"File not found: {args.source}")
+        sys.exit(1)
+
+    try:
+        rc = run_script(args.source, args.deps)
+        sys.exit(rc)
+    except ValueError as exc:
+        print(exc)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/Hello.java
+++ b/samples/Hello.java
@@ -1,0 +1,5 @@
+public class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello from Java");
+    }
+}

--- a/samples/hello.c
+++ b/samples/hello.c
@@ -1,0 +1,2 @@
+#include <stdio.h>
+int main(){printf("Hello from C\n");return 0;}

--- a/samples/hello.cpp
+++ b/samples/hello.cpp
@@ -1,0 +1,2 @@
+#include <iostream>
+int main(){std::cout << "Hello from C++" << std::endl; return 0;}

--- a/samples/hello.js
+++ b/samples/hello.js
@@ -1,0 +1,1 @@
+console.log('Hello from JavaScript');

--- a/samples/hello.py
+++ b/samples/hello.py
@@ -1,0 +1,1 @@
+print('Hello from Python')

--- a/samples/hello.rb
+++ b/samples/hello.rb
@@ -1,0 +1,1 @@
+puts 'Hello from Ruby'

--- a/samples/use_local.py
+++ b/samples/use_local.py
@@ -1,0 +1,2 @@
+import localpkg
+print(localpkg.value())

--- a/samples/use_stringer.js
+++ b/samples/use_stringer.js
@@ -1,0 +1,2 @@
+const rev = require('stringer');
+console.log(rev('abc'));

--- a/server.js
+++ b/server.js
@@ -1,0 +1,74 @@
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const LANGUAGE_EXT = {
+  python: '.py',
+  javascript: '.js',
+  ruby: '.rb',
+  php: '.php',
+  perl: '.pl',
+  c: '.c',
+  cpp: '.cpp',
+  java: '.java'
+};
+
+function runCode(lang, code, deps = '') {
+  const ext = LANGUAGE_EXT[lang];
+  if (!ext) {
+    return `Unsupported language: ${lang}`;
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-'));
+  const file = path.join(dir, 'prog' + ext);
+  fs.writeFileSync(file, code);
+  const args = ['run_code.py', file];
+  const depList = deps.trim().split(/\s+/).filter(d => d);
+  if (depList.length > 0) {
+    args.push('--deps', ...depList);
+  }
+  const result = spawnSync('python3', args, { encoding: 'utf8' });
+  return result.stdout + result.stderr;
+}
+
+function handleRequest(req, res) {
+  if (req.method === 'POST' && req.url === '/run') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const lang = params.get('language');
+      const code = params.get('code') || '';
+      const deps = params.get('deps') || '';
+      const output = runCode(lang, code, deps);
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(output);
+    });
+  } else {
+    const options = Object.keys(LANGUAGE_EXT)
+      .map(l => `<option value="${l}">${l}</option>`) 
+      .join('\n');
+    const page = `<!doctype html>
+<title>Code Runner</title>
+<form method="post" action="/run">
+<select name="language">
+${options}
+</select><br>
+<textarea name="code" rows="10" cols="40"></textarea><br>
+<input type="text" name="deps" placeholder="Dependencies (space separated)"><br>
+<input type="submit" value="Run">
+</form>`;
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(page);
+  }
+}
+
+if (require.main === module) {
+  const port = parseInt(process.env.PORT || '8000', 10);
+  http.createServer(handleRequest).listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+} else {
+  module.exports = { runCode, handleRequest };
+}

--- a/test_run_code.py
+++ b/test_run_code.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+
+
+def run_sample(sample, deps=None):
+    cmd = [sys.executable, 'run_code.py', sample]
+    if deps:
+        cmd += ['--deps'] + deps
+    result = subprocess.run(cmd, text=True, capture_output=True)
+    return result.stdout.strip(), result.returncode
+
+
+def test_python_sample():
+    out, rc = run_sample('samples/hello.py')
+    assert rc == 0
+    assert out == 'Hello from Python'
+
+
+def run_node(lang, code, deps=''):
+    import json
+    script = (
+        f"const r=require('./server.js');"
+        f"process.stdout.write(r.runCode({json.dumps(lang)},{json.dumps(code)},{json.dumps(deps)}));"
+    )
+    result = subprocess.run(['node', '-e', script], text=True, capture_output=True)
+    return result.stdout.strip(), result.returncode
+
+
+def test_web_python():
+    out, rc = run_node('python', "print('OK')")
+    assert rc == 0
+    assert 'OK' in out
+
+
+def test_python_with_dep():
+    out, rc = run_sample('samples/use_local.py', ['libs/localpkg'])
+    assert rc == 0
+    assert out == '42'
+
+
+def test_node_with_dep():
+    out, rc = run_node('javascript', "const rev=require('stringer');console.log(rev('abc'));", 'libs/stringer')
+    assert rc == 0
+    assert 'cba' in out


### PR DESCRIPTION
## Summary
- install local or remote packages when running code via `--deps`
- add `deps` field to the web UI to allow dependencies
- provide small local packages for Python and JavaScript
- extend tests for dependency handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b5765a208324a304a7096eb9711b